### PR TITLE
Make iterables.pairs() work for iterators

### DIFF
--- a/src/iterables/pairs.test.ts
+++ b/src/iterables/pairs.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import pairs from "./pairs";
+import generate from "./generate";
 
 describe("pairs", () => {
   it("basic", () => {
@@ -26,5 +27,33 @@ describe("pairs", () => {
   });
   it("one item in iterable", () => {
     expect(Array.from(pairs()(["one"]))).to.deep.equal([]);
+  });
+  it("iterator", () => {
+    expect(Array.from(pairs()(generate((i) => i, 5)))).to.deep.equal([
+      { first: 0, second: 1 },
+      { first: 1, second: 2 },
+      { first: 2, second: 3 },
+      { first: 3, second: 4 },
+    ]);
+  });
+
+  it("infinite iterator", () => {
+    const iter = pairs()(generate((i) => i));
+    expect(iter.next()).to.deep.equal({
+      value: { first: 0, second: 1 },
+      done: false,
+    });
+    expect(iter.next()).to.deep.equal({
+      value: { first: 1, second: 2 },
+      done: false,
+    });
+    expect(iter.next()).to.deep.equal({
+      value: { first: 2, second: 3 },
+      done: false,
+    });
+    expect(iter.next()).to.deep.equal({
+      value: { first: 3, second: 4 },
+      done: false,
+    });
   });
 });

--- a/src/iterables/pairs.ts
+++ b/src/iterables/pairs.ts
@@ -3,6 +3,17 @@ import drop from "./drop";
 import zip from "./zip";
 
 export default function pairs<T>(offset = 1) {
-  return (iterable: Iterable<T>): Iterable<{ first: T; second: T }> =>
-    chain(zip(iterable, drop<T>(offset)(iterable))).end();
+  return function* (iterable: Iterable<T>): Generator<{ first: T; second: T }> {
+    const pastValues = [];
+    let index = 0;
+    for (const x of iterable) {
+      if (pastValues.length < offset) {
+        pastValues.push(x);
+      } else {
+        yield { first: pastValues[index % offset], second: x };
+        pastValues[index % offset] = x;
+      }
+      index++;
+    }
+  };
 }


### PR DESCRIPTION
Fixes #1